### PR TITLE
Refactor perl description cleaner to python

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,40 @@
-
+queries:
+  # Get external transaction descriptions that need cleaning (full clean)
+  get_ext_full: |
+    SELECT extrtxndescnbr, extrtxndesctext
+    FROM extrtxndesc
+    WHERE extrtxndesctext != REGEXP_REPLACE(extrtxndesctext,'[^0-9A-Za-z !@#\$\%*\(\)-_=+{}|\\;:,.<>/?^&''`~"]', ' ')
+  
+  # Get external transaction descriptions that need cleaning (incremental)
+  get_ext_incremental: |
+    SELECT extrtxndescnbr, extrtxndesctext
+    FROM extrtxndesc
+    WHERE extrtxndesctext != REGEXP_REPLACE(extrtxndesctext,'[^0-9A-Za-z !@#\$\%*\(\)-_=+{}|\\;:,.<>/?^&''`~"]', ' ')
+    AND datelastmaint > sysdate - :days_back
+  
+  # Get internal transaction descriptions that need cleaning (full clean)
+  get_int_full: |
+    SELECT intrtxndescnbr, intrtxndesctext
+    FROM intrtxndesc
+    WHERE intrtxndesctext != REGEXP_REPLACE(intrtxndesctext,'[^0-9A-Za-z !@#\$\%*\(\)-_=+{}|\\;:,.<>/?^&''`~"]', ' ')
+  
+  # Get internal transaction descriptions that need cleaning (incremental)
+  get_int_incremental: |
+    SELECT intrtxndescnbr, intrtxndesctext
+    FROM intrtxndesc
+    WHERE intrtxndesctext != REGEXP_REPLACE(intrtxndesctext,'[^0-9A-Za-z !@#\$\%*\(\)-_=+{}|\\;:,.<>/?^&''`~"]', ' ')
+    AND datelastmaint > sysdate - :days_back
+  
+  # Update external transaction descriptions
+  update_ext: |
+    UPDATE extrtxndesc
+    SET extrtxndesctext = :new_text,
+        datelastmaint = sysdate
+    WHERE extrtxndescnbr = :desc_nbr
+  
+  # Update internal transaction descriptions
+  update_int: |
+    UPDATE intrtxndesc
+    SET intrtxndesctext = :new_text,
+        datelastmaint = sysdate
+    WHERE intrtxndescnbr = :desc_nbr

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,84 @@
+import os
+import pathlib
+import pytest
+import sys
+from rtxn_description_cleaner import AppWorxEnum, get_apwx, parse_args
+
+
+TEST_BASE_PATH = pathlib.Path(os.path.dirname(__file__))
+
+# Script arguments for testing
+SCRIPT_ARGUMENTS = {
+    str(AppWorxEnum.TNS_SERVICE_NAME): "DNATST3",
+    str(AppWorxEnum.FULL_CLEAN_YN): "N",
+    str(AppWorxEnum.DAYS_BACK): "3",
+    str(AppWorxEnum.RPT_ONLY_YN): "Y",
+    str(AppWorxEnum.OUTPUT_FILE_PATH): str(TEST_BASE_PATH),
+    str(AppWorxEnum.OUTPUT_FILE_NAME): "test_rtxn_desc_cleaner_audit_log.csv",
+}
+
+
+def setup(script_args: dict):
+    """Setup command line arguments to be passed to AppWorx library"""
+    for k, v in script_args.items():
+        sys.argv.append(f"{k}={v}")
+
+
+def teardown(script_args: dict):
+    """Cleanup command line arguments"""
+    for _ in script_args:
+        sys.argv.pop()
+
+
+@pytest.fixture(scope="module")
+def apwx():
+    """Fixture to provide configured AppWorx object for testing"""
+    setup(SCRIPT_ARGUMENTS)
+    appworx = parse_args(get_apwx())
+    teardown(SCRIPT_ARGUMENTS)
+    return appworx
+
+
+@pytest.fixture
+def sample_ext_data():
+    """Fixture providing sample external transaction data"""
+    return [
+        {
+            'EXTRTXNDESCNBR': 1,
+            'EXTRTXNDESCTEXT': 'Test Description with bad chars\x00\x01'
+        },
+        {
+            'EXTRTXNDESCNBR': 2,
+            'EXTRTXNDESCTEXT': 'Another description with unicode café'
+        }
+    ]
+
+
+@pytest.fixture
+def sample_int_data():
+    """Fixture providing sample internal transaction data"""
+    return [
+        {
+            'INTRTXNDESCNBR': 1,
+            'INTRTXNDESCTEXT': 'Internal desc with special chars\x7f'
+        },
+        {
+            'INTRTXNDESCNBR': 2,
+            'INTRTXNDESCTEXT': 'Normal internal description'
+        }
+    ]
+
+
+@pytest.fixture
+def mock_config():
+    """Fixture providing mock configuration"""
+    return {
+        'queries': {
+            'get_ext_full': 'SELECT extrtxndescnbr, extrtxndesctext FROM extrtxndesc',
+            'get_ext_incremental': 'SELECT extrtxndescnbr, extrtxndesctext FROM extrtxndesc WHERE datelastmaint > sysdate - :days_back',
+            'get_int_full': 'SELECT intrtxndescnbr, intrtxndesctext FROM intrtxndesc',
+            'get_int_incremental': 'SELECT intrtxndescnbr, intrtxndesctext FROM intrtxndesc WHERE datelastmaint > sysdate - :days_back',
+            'update_ext': 'UPDATE extrtxndesc SET extrtxndesctext = :new_text WHERE extrtxndescnbr = :desc_nbr',
+            'update_int': 'UPDATE intrtxndesc SET intrtxndesctext = :new_text WHERE intrtxndescnbr = :desc_nbr'
+        }
+    }

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ TEST_BASE_PATH = pathlib.Path(os.path.dirname(__file__))
 # Script arguments for testing
 SCRIPT_ARGUMENTS = {
     str(AppWorxEnum.TNS_SERVICE_NAME): "DNATST3",
+    str(AppWorxEnum.CONFIG_FILE): str(TEST_BASE_PATH / "config.yaml"),
     str(AppWorxEnum.FULL_CLEAN_YN): "N",
     str(AppWorxEnum.DAYS_BACK): "3",
     str(AppWorxEnum.RPT_ONLY_YN): "Y",

--- a/rtxn_description_cleaner.py
+++ b/rtxn_description_cleaner.py
@@ -17,6 +17,7 @@ class AppWorxEnum(Enum):
     """Define AppWorx arguments here to avoid hard-coded strings."""
 
     TNS_SERVICE_NAME = auto()
+    CONFIG_FILE = auto()
     FULL_CLEAN_YN = auto()
     DAYS_BACK = auto()
     RPT_ONLY_YN = auto()
@@ -249,6 +250,9 @@ def parse_args(apwx: Apwx) -> Apwx:
     parser = apwx.parser
     parser.add_arg(str(AppWorxEnum.TNS_SERVICE_NAME), type=str, required=True)
     parser.add_arg(
+        str(AppWorxEnum.CONFIG_FILE), type=r"(\.yml|\.yaml)$", required=True
+    )
+    parser.add_arg(
         str(AppWorxEnum.FULL_CLEAN_YN), choices=["Y", "N"], default="N", required=False
     )
     parser.add_arg(
@@ -272,16 +276,16 @@ def dna_db_connect(apwx) -> DbConnection:
     return apwx.db_connect(autocommit=False)
 
 
-def get_config() -> dict:
+def get_config(apwx: Apwx) -> dict:
     """Loads config YAML into a dictionary."""
-    with open("config.yaml", "r") as f:
+    with open(apwx.args.CONFIG_FILE, "r") as f:
         return yaml.safe_load(f)
 
 
 def initialize(apwx) -> ScriptData:
     """Initialize objects required by the script to call external systems."""
     dbh = dna_db_connect(apwx)
-    config = get_config()
+    config = get_config(apwx)
     
     # Create output file path
     output_path = Path(apwx.args.OUTPUT_FILE_PATH)

--- a/rtxn_description_cleaner.py
+++ b/rtxn_description_cleaner.py
@@ -1,0 +1,336 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from ftfcu_appworx import Apwx, JobTime
+from oracledb import Connection as DbConnection
+from pathlib import Path
+from typing import Any, Optional, List, Dict
+import csv
+import datetime
+import re
+import unicodedata
+import yaml
+
+__version__ = "0.01"
+
+
+class AppWorxEnum(Enum):
+    """Define AppWorx arguments here to avoid hard-coded strings."""
+
+    TNS_SERVICE_NAME = auto()
+    FULL_CLEAN_YN = auto()
+    DAYS_BACK = auto()
+    RPT_ONLY_YN = auto()
+    OUTPUT_FILE_PATH = auto()
+    OUTPUT_FILE_NAME = auto()
+
+    def __str__(self):
+        return self.name
+
+
+@dataclass
+class ScriptData:
+    """Class that holds all the structures and data needed by the script."""
+    
+    apwx: Apwx
+    dbh: DbConnection
+    config: Any
+    data_ext: List[Dict] = None
+    data_int: List[Dict] = None
+    output_file: str = None
+
+
+def run(apwx: Apwx) -> bool:
+    """Main processing function for the script."""
+    
+    script_data = initialize(apwx)
+    
+    log("Starting RTXN Description Cleaner Job")
+    
+    log("Connecting to DNA DB")
+    
+    if script_data.apwx.args.FULL_CLEAN_YN == 'Y':
+        log("Cleansing Fields - Full Clean")
+    else:
+        log("Cleansing Fields - Partial Clean")
+    
+    log("Getting Ext and Int Descriptions To Be Cleaned")
+    
+    # Get data based on full clean or incremental
+    if script_data.apwx.args.FULL_CLEAN_YN == 'Y':
+        script_data.data_ext = get_data_ext(script_data.dbh, script_data.config, full_clean=True)
+        script_data.data_int = get_data_int(script_data.dbh, script_data.config, full_clean=True)
+    else:
+        script_data.data_ext = get_data_ext(script_data.dbh, script_data.config, full_clean=False, days_back=script_data.apwx.args.DAYS_BACK)
+        script_data.data_int = get_data_int(script_data.dbh, script_data.config, full_clean=False, days_back=script_data.apwx.args.DAYS_BACK)
+    
+    log("Cleaning descriptions")
+    clean_data(script_data)
+    
+    log("Updating database")
+    update_desc_ext(script_data)
+    update_desc_int(script_data)
+    
+    log("Writing Audit Report")
+    write_report(script_data)
+    
+    log("Job Finished")
+    
+    return True
+
+
+def get_data_ext(dbh: DbConnection, config: dict, full_clean: bool = True, days_back: int = 3) -> List[Dict]:
+    """Get external transaction descriptions that need cleaning."""
+    
+    if full_clean:
+        sql = config['queries']['get_ext_full']
+    else:
+        sql = config['queries']['get_ext_incremental']
+        
+    sql_params = {'days_back': days_back} if not full_clean else None
+    
+    return execute_sql(dbh, sql, 'SELECT', sql_params)
+
+
+def get_data_int(dbh: DbConnection, config: dict, full_clean: bool = True, days_back: int = 3) -> List[Dict]:
+    """Get internal transaction descriptions that need cleaning."""
+    
+    if full_clean:
+        sql = config['queries']['get_int_full']
+    else:
+        sql = config['queries']['get_int_incremental']
+        
+    sql_params = {'days_back': days_back} if not full_clean else None
+    
+    return execute_sql(dbh, sql, 'SELECT', sql_params)
+
+
+def clean_data(script_data: ScriptData) -> None:
+    """Clean bad characters from description text."""
+    
+    # Clean external descriptions
+    for record in script_data.data_ext:
+        record['EXTRTXNDESCTEXT_OLD'] = record['EXTRTXNDESCTEXT']
+        record['EXTRTXNDESCTEXT_NEW'] = clean_bad_chars(unidecode_text(record['EXTRTXNDESCTEXT'].strip()))
+    
+    # Clean internal descriptions
+    for record in script_data.data_int:
+        record['INTRTXNDESCTEXT_OLD'] = record['INTRTXNDESCTEXT']
+        record['INTRTXNDESCTEXT_NEW'] = clean_bad_chars(unidecode_text(record['INTRTXNDESCTEXT'].strip()))
+
+
+def clean_bad_chars(text: str) -> str:
+    """Remove non-ASCII and non-printable characters."""
+    # Remove non-ASCII characters
+    text = ''.join(char for char in text if ord(char) < 128)
+    # Remove non-printable characters
+    text = ''.join(char for char in text if char.isprintable() or char.isspace())
+    return text
+
+
+def unidecode_text(text: str) -> str:
+    """Convert Unicode text to ASCII equivalent."""
+    return unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('ascii')
+
+
+def update_desc_ext(script_data: ScriptData) -> None:
+    """Update external transaction descriptions in database."""
+    
+    sql = script_data.config['queries']['update_ext']
+    
+    # Prepare data for batch update
+    update_data = []
+    for record in script_data.data_ext:
+        update_data.append({
+            'new_text': record['EXTRTXNDESCTEXT_NEW'],
+            'desc_nbr': record['EXTRTXNDESCNBR']
+        })
+    
+    post_trans(script_data, sql, update_data)
+
+
+def update_desc_int(script_data: ScriptData) -> None:
+    """Update internal transaction descriptions in database."""
+    
+    sql = script_data.config['queries']['update_int']
+    
+    # Prepare data for batch update
+    update_data = []
+    for record in script_data.data_int:
+        update_data.append({
+            'new_text': record['INTRTXNDESCTEXT_NEW'],
+            'desc_nbr': record['INTRTXNDESCNBR']
+        })
+    
+    post_trans(script_data, sql, update_data)
+
+
+def post_trans(script_data: ScriptData, sql: str, data: List[Dict]) -> None:
+    """Execute batch transaction with commit/rollback logic."""
+    
+    try:
+        with script_data.dbh.cursor() as cursor:
+            batch_size = 5000
+            total_records = len(data)
+            
+            for i in range(0, total_records, batch_size):
+                batch = data[i:i + batch_size]
+                cursor.executemany(sql, batch, batcherrors=True)
+                
+                # Check for batch errors
+                batch_errors = cursor.getbatcherrors()
+                if batch_errors:
+                    report_errors("Posting errors: ", batch_errors)
+                
+                commit_rollback(script_data)
+                log(f"Updated {min(i + batch_size, total_records)} records")
+                
+    except Exception as e:
+        log(f"Error in post_trans: {e}")
+        raise
+
+
+def report_errors(msg: str, errors: List) -> None:
+    """Report any batch processing errors."""
+    if errors:
+        for error in errors:
+            log(f"{msg} Error: {error.message}")
+
+
+def write_report(script_data: ScriptData) -> None:
+    """Generate audit report in CSV format."""
+    
+    output_file = script_data.output_file
+    
+    with open(output_file, 'w', newline='', encoding='utf-8') as f:
+        f.write('RTXN DESCRIPTION CLEANER AUDIT REPORT\n')
+        f.write(f'RUN DATE: {datetime.datetime.now()}\n')
+        f.write(f'REPORT ONLY YN: {script_data.apwx.args.RPT_ONLY_YN}\n\n')
+        
+        f.write('EXT DESCRIPTIONS\n')
+        if script_data.data_ext:
+            print_csv(f, script_data.data_ext, ['EXTRTXNDESCNBR', 'EXTRTXNDESCTEXT_OLD', 'EXTRTXNDESCTEXT_NEW'])
+        
+        f.write('\n\nINT DESCRIPTIONS\n')
+        if script_data.data_int:
+            print_csv(f, script_data.data_int, ['INTRTXNDESCNBR', 'INTRTXNDESCTEXT_OLD', 'INTRTXNDESCTEXT_NEW'])
+        
+        f.write('\nEND\n')
+
+
+def print_csv(file_handle, data: List[Dict], field_order: List[str]) -> None:
+    """Print data as CSV to file handle."""
+    if not data:
+        return
+        
+    writer = csv.DictWriter(file_handle, fieldnames=field_order, quoting=csv.QUOTE_ALL)
+    writer.writeheader()
+    
+    for record in data:
+        # Only write fields that are in field_order
+        filtered_record = {field: record.get(field, '') for field in field_order}
+        writer.writerow(filtered_record)
+
+
+def commit_rollback(script_data: ScriptData) -> None:
+    """Commit or rollback based on RPT_ONLY_YN parameter."""
+    if script_data.apwx.args.RPT_ONLY_YN == 'Y':
+        script_data.dbh.rollback()
+    else:
+        script_data.dbh.commit()
+
+
+def get_apwx() -> Apwx:
+    """Creates the appworx object."""
+    return Apwx(["OSIUPDATE", "OSIUPDATE_PW"])
+
+
+def parse_args(apwx: Apwx) -> Apwx:
+    """Validates the parameters provided to the script."""
+    parser = apwx.parser
+    parser.add_arg(str(AppWorxEnum.TNS_SERVICE_NAME), type=str, required=True)
+    parser.add_arg(
+        str(AppWorxEnum.FULL_CLEAN_YN), choices=["Y", "N"], default="N", required=False
+    )
+    parser.add_arg(
+        str(AppWorxEnum.DAYS_BACK), type=int, default=3, required=False
+    )
+    parser.add_arg(
+        str(AppWorxEnum.RPT_ONLY_YN), choices=["Y", "N"], default="Y", required=False
+    )
+    parser.add_arg(
+        str(AppWorxEnum.OUTPUT_FILE_PATH), type=parser.dir_validator, default="./Logs", required=False
+    )
+    parser.add_arg(
+        str(AppWorxEnum.OUTPUT_FILE_NAME), type=str, default="rtxn_desc_cleaner_audit_log.csv", required=False
+    )
+    apwx.parse_args()
+    return apwx
+
+
+def dna_db_connect(apwx) -> DbConnection:
+    """Creates the database connection object."""
+    return apwx.db_connect(autocommit=False)
+
+
+def get_config() -> dict:
+    """Loads config YAML into a dictionary."""
+    with open("config.yaml", "r") as f:
+        return yaml.safe_load(f)
+
+
+def initialize(apwx) -> ScriptData:
+    """Initialize objects required by the script to call external systems."""
+    dbh = dna_db_connect(apwx)
+    config = get_config()
+    
+    # Create output file path
+    output_path = Path(apwx.args.OUTPUT_FILE_PATH)
+    output_file = output_path / apwx.args.OUTPUT_FILE_NAME
+    
+    return ScriptData(apwx=apwx, dbh=dbh, config=config, output_file=str(output_file))
+
+
+def execute_sql(conn: DbConnection, sql_statement: str, action: str, sql_params=None) -> List[Dict]:
+    """Executes provided sql_statement with provided input parameters if present.
+    Args:
+        conn: Database connection object used to connect to DNA.
+        sql_statement: The SQL statement to be executed.
+        action: The specific type of SQL statement. This is used to determine how to execute.
+        sql_params: Any bind variables that are used. Typically, this is a dictionary.
+    Returns:
+        SELECT statements will always return a list of dictionaries.
+    """
+    try:
+        with conn.cursor() as cursor:
+            if action == 'SELECT':
+                if sql_params is not None:
+                    cursor.execute(sql_statement, sql_params)
+                else:
+                    cursor.execute(sql_statement)
+                        
+                column_names = [col[0] for col in cursor.description]
+                cursor.rowfactory = lambda *args: dict(zip(column_names, args))
+                return cursor.fetchall()
+                
+            elif action in ('INSERT', 'UPDATE', 'MERGE', 'DELETE'):
+                cursor.executemany(sql_statement, sql_params, batcherrors=True)
+                batch_errors = cursor.getbatcherrors()
+                if batch_errors:
+                    for error in batch_errors:
+                        error_index = error.offset
+                        log(f'Error: {error.message} during {action}. Attempted input: {sql_params[error_index]}')
+                    raise Exception(f'One or more errors occurred during the {action} process.')
+                        
+    except Exception as e:
+        raise Exception(f"SQL error = {e}")
+
+
+def log(message: str) -> None:
+    """Log message with timestamp."""
+    print(f"{datetime.datetime.now()}: {message}")
+
+
+if __name__ == "__main__":
+    JobTime().print_start()
+    run(parse_args(get_apwx()))
+    JobTime().print_end()

--- a/test_rtxn_description_cleaner.py
+++ b/test_rtxn_description_cleaner.py
@@ -1,0 +1,339 @@
+import pytest
+from unittest.mock import Mock, patch, mock_open
+from rtxn_description_cleaner import (
+    run, get_data_ext, get_data_int, clean_data, clean_bad_chars, 
+    unidecode_text, update_desc_ext, update_desc_int, write_report,
+    ScriptData, AppWorxEnum
+)
+
+
+def test_run(apwx):
+    """Using the `apwx` fixture from conftest.py, execute the run function"""
+    with patch('rtxn_description_cleaner.initialize') as mock_init, \
+         patch('rtxn_description_cleaner.get_data_ext') as mock_get_ext, \
+         patch('rtxn_description_cleaner.get_data_int') as mock_get_int, \
+         patch('rtxn_description_cleaner.clean_data') as mock_clean, \
+         patch('rtxn_description_cleaner.update_desc_ext') as mock_update_ext, \
+         patch('rtxn_description_cleaner.update_desc_int') as mock_update_int, \
+         patch('rtxn_description_cleaner.write_report') as mock_report, \
+         patch('rtxn_description_cleaner.log') as mock_log:
+        
+        # Setup mock data
+        mock_script_data = Mock()
+        mock_script_data.apwx.args.FULL_CLEAN_YN = 'N'
+        mock_script_data.apwx.args.DAYS_BACK = 3
+        mock_init.return_value = mock_script_data
+        
+        mock_get_ext.return_value = []
+        mock_get_int.return_value = []
+        
+        result = run(apwx)
+        
+        assert result is True
+        mock_init.assert_called_once_with(apwx)
+        mock_clean.assert_called_once()
+        mock_update_ext.assert_called_once()
+        mock_update_int.assert_called_once()
+        mock_report.assert_called_once()
+
+
+def test_get_data_ext_full_clean(mocker):
+    """Test getting external data with full clean"""
+    mock_dbh = Mock()
+    mock_config = {
+        'queries': {
+            'get_ext_full': 'SELECT * FROM extrtxndesc'
+        }
+    }
+    expected_data = [{'EXTRTXNDESCNBR': 1, 'EXTRTXNDESCTEXT': 'Test Description'}]
+    
+    mocker.patch(
+        'rtxn_description_cleaner.execute_sql',
+        return_value=expected_data
+    )
+    
+    result = get_data_ext(mock_dbh, mock_config, full_clean=True)
+    
+    assert result == expected_data
+
+
+def test_get_data_ext_incremental(mocker):
+    """Test getting external data with incremental clean"""
+    mock_dbh = Mock()
+    mock_config = {
+        'queries': {
+            'get_ext_incremental': 'SELECT * FROM extrtxndesc WHERE datelastmaint > sysdate - :days_back'
+        }
+    }
+    expected_data = [{'EXTRTXNDESCNBR': 1, 'EXTRTXNDESCTEXT': 'Test Description'}]
+    
+    mocker.patch(
+        'rtxn_description_cleaner.execute_sql',
+        return_value=expected_data
+    )
+    
+    result = get_data_ext(mock_dbh, mock_config, full_clean=False, days_back=5)
+    
+    assert result == expected_data
+
+
+def test_get_data_int_full_clean(mocker):
+    """Test getting internal data with full clean"""
+    mock_dbh = Mock()
+    mock_config = {
+        'queries': {
+            'get_int_full': 'SELECT * FROM intrtxndesc'
+        }
+    }
+    expected_data = [{'INTRTXNDESCNBR': 1, 'INTRTXNDESCTEXT': 'Test Description'}]
+    
+    mocker.patch(
+        'rtxn_description_cleaner.execute_sql',
+        return_value=expected_data
+    )
+    
+    result = get_data_int(mock_dbh, mock_config, full_clean=True)
+    
+    assert result == expected_data
+
+
+def test_clean_bad_chars():
+    """Test cleaning bad characters from text"""
+    # Test with non-ASCII and non-printable characters
+    test_text = "Hello\x00World\x7f\x80\x9fTest"
+    expected = "HelloWorldTest"
+    
+    result = clean_bad_chars(test_text)
+    
+    assert result == expected
+
+
+def test_clean_bad_chars_with_unicode():
+    """Test cleaning bad characters with Unicode"""
+    test_text = "Café\x00\x01\x02"
+    expected = "Café"
+    
+    result = clean_bad_chars(test_text)
+    
+    # Should remove non-printable but keep printable Unicode
+    assert len(result) > 0
+    assert '\x00' not in result
+    assert '\x01' not in result
+    assert '\x02' not in result
+
+
+def test_unidecode_text():
+    """Test Unicode to ASCII conversion"""
+    test_text = "Café résumé naïve"
+    
+    result = unidecode_text(test_text)
+    
+    # Should convert accented characters to ASCII equivalents
+    assert 'é' not in result
+    assert 'ï' not in result
+    assert len(result) > 0
+
+
+def test_clean_data():
+    """Test cleaning data function"""
+    mock_script_data = Mock()
+    mock_script_data.data_ext = [
+        {'EXTRTXNDESCTEXT': '  Test Description\x00  '}
+    ]
+    mock_script_data.data_int = [
+        {'INTRTXNDESCTEXT': '  Internal Desc\x01  '}
+    ]
+    
+    clean_data(mock_script_data)
+    
+    # Check that old values are preserved
+    assert 'EXTRTXNDESCTEXT_OLD' in mock_script_data.data_ext[0]
+    assert 'INTRTXNDESCTEXT_OLD' in mock_script_data.data_int[0]
+    
+    # Check that new values are created
+    assert 'EXTRTXNDESCTEXT_NEW' in mock_script_data.data_ext[0]
+    assert 'INTRTXNDESCTEXT_NEW' in mock_script_data.data_int[0]
+
+
+def test_update_desc_ext(mocker):
+    """Test updating external descriptions"""
+    mock_script_data = Mock()
+    mock_script_data.config = {
+        'queries': {
+            'update_ext': 'UPDATE extrtxndesc SET extrtxndesctext = :new_text WHERE extrtxndescnbr = :desc_nbr'
+        }
+    }
+    mock_script_data.data_ext = [
+        {
+            'EXTRTXNDESCNBR': 1,
+            'EXTRTXNDESCTEXT_NEW': 'Cleaned Text'
+        }
+    ]
+    
+    mock_post_trans = mocker.patch('rtxn_description_cleaner.post_trans')
+    
+    update_desc_ext(mock_script_data)
+    
+    mock_post_trans.assert_called_once()
+
+
+def test_update_desc_int(mocker):
+    """Test updating internal descriptions"""
+    mock_script_data = Mock()
+    mock_script_data.config = {
+        'queries': {
+            'update_int': 'UPDATE intrtxndesc SET intrtxndesctext = :new_text WHERE intrtxndescnbr = :desc_nbr'
+        }
+    }
+    mock_script_data.data_int = [
+        {
+            'INTRTXNDESCNBR': 1,
+            'INTRTXNDESCTEXT_NEW': 'Cleaned Text'
+        }
+    ]
+    
+    mock_post_trans = mocker.patch('rtxn_description_cleaner.post_trans')
+    
+    update_desc_int(mock_script_data)
+    
+    mock_post_trans.assert_called_once()
+
+
+def test_write_report(mocker):
+    """Test writing audit report"""
+    mock_script_data = Mock()
+    mock_script_data.output_file = 'test_output.csv'
+    mock_script_data.apwx.args.RPT_ONLY_YN = 'Y'
+    mock_script_data.data_ext = [
+        {
+            'EXTRTXNDESCNBR': 1,
+            'EXTRTXNDESCTEXT_OLD': 'Old Text',
+            'EXTRTXNDESCTEXT_NEW': 'New Text'
+        }
+    ]
+    mock_script_data.data_int = [
+        {
+            'INTRTXNDESCNBR': 2,
+            'INTRTXNDESCTEXT_OLD': 'Old Internal',
+            'INTRTXNDESCTEXT_NEW': 'New Internal'
+        }
+    ]
+    
+    mock_file = mock_open()
+    
+    with patch('builtins.open', mock_file):
+        write_report(mock_script_data)
+    
+    mock_file.assert_called_once_with('test_output.csv', 'w', newline='', encoding='utf-8')
+    
+    # Check that file was written to
+    handle = mock_file()
+    assert handle.write.called
+
+
+def test_write_report_empty_data(mocker):
+    """Test writing audit report with empty data"""
+    mock_script_data = Mock()
+    mock_script_data.output_file = 'test_output.csv'
+    mock_script_data.apwx.args.RPT_ONLY_YN = 'N'
+    mock_script_data.data_ext = []
+    mock_script_data.data_int = []
+    
+    mock_file = mock_open()
+    
+    with patch('builtins.open', mock_file):
+        write_report(mock_script_data)
+    
+    mock_file.assert_called_once()
+
+
+def test_execute_sql_select_with_params(mocker):
+    """Test execute_sql with SELECT and parameters"""
+    from rtxn_description_cleaner import execute_sql
+    
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.description = [('COLUMN1',), ('COLUMN2',)]
+    mock_cursor.fetchall.return_value = [('value1', 'value2')]
+    
+    sql = "SELECT * FROM table WHERE id = :id"
+    params = {'id': 1}
+    
+    result = execute_sql(mock_conn, sql, 'SELECT', params)
+    
+    mock_cursor.execute.assert_called_once_with(sql, params)
+    assert len(result) == 1
+
+
+def test_execute_sql_select_no_params(mocker):
+    """Test execute_sql with SELECT and no parameters"""
+    from rtxn_description_cleaner import execute_sql
+    
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.description = [('COLUMN1',), ('COLUMN2',)]
+    mock_cursor.fetchall.return_value = [('value1', 'value2')]
+    
+    sql = "SELECT * FROM table"
+    
+    result = execute_sql(mock_conn, sql, 'SELECT')
+    
+    mock_cursor.execute.assert_called_once_with(sql)
+    assert len(result) == 1
+
+
+def test_execute_sql_update(mocker):
+    """Test execute_sql with UPDATE"""
+    from rtxn_description_cleaner import execute_sql
+    
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.getbatcherrors.return_value = []
+    
+    sql = "UPDATE table SET col = :val WHERE id = :id"
+    params = [{'val': 'new_value', 'id': 1}]
+    
+    execute_sql(mock_conn, sql, 'UPDATE', params)
+    
+    mock_cursor.executemany.assert_called_once_with(sql, params, batcherrors=True)
+
+
+def test_execute_sql_update_with_errors(mocker):
+    """Test execute_sql with UPDATE that has batch errors"""
+    from rtxn_description_cleaner import execute_sql
+    
+    mock_conn = Mock()
+    mock_cursor = Mock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    
+    # Mock batch error
+    mock_error = Mock()
+    mock_error.offset = 0
+    mock_error.message = "Test error"
+    mock_cursor.getbatcherrors.return_value = [mock_error]
+    
+    sql = "UPDATE table SET col = :val WHERE id = :id"
+    params = [{'val': 'new_value', 'id': 1}]
+    
+    with pytest.raises(Exception) as exc_info:
+        execute_sql(mock_conn, sql, 'UPDATE', params)
+    
+    assert "One or more errors occurred during the UPDATE process" in str(exc_info.value)
+
+
+def test_execute_sql_exception():
+    """Test execute_sql with database exception"""
+    from rtxn_description_cleaner import execute_sql
+    
+    mock_conn = Mock()
+    mock_conn.cursor.side_effect = Exception("Database connection error")
+    
+    sql = "SELECT * FROM table"
+    
+    with pytest.raises(Exception) as exc_info:
+        execute_sql(mock_conn, sql, 'SELECT')
+    
+    assert "SQL error" in str(exc_info.value)


### PR DESCRIPTION
Refactor `rtxn_desc_cleaner.pl` Perl script to Python to modernize the codebase and integrate with existing Python infrastructure.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fbc8713-15c5-4d79-a7a8-ec308cbed608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fbc8713-15c5-4d79-a7a8-ec308cbed608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

